### PR TITLE
Changes from background composer bc-a71be75b-df48-47d3-bfd9-2c6f185a7e15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.2.9"
+            "php": "8.2.0"
         },
         "prepend-autoloader": false,
         "sort-packages": true,

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,9 +1,9 @@
 [phases.setup]
 nixPkgs = [
-    '(php83.withExtensions (pe: pe.enabled ++ []))',
+    '(php82.withExtensions (pe: pe.enabled ++ []))',
     'nginx',
     'libmysqlclient',
-    'php83Packages.composer',
+    'php82Packages.composer',
     'nodejs_18',
     'npm-9_x'
 ]


### PR DESCRIPTION
Align PHP version to 8.2 in Nixpacks and Composer configuration to resolve build errors.

The previous PHP 8.3 environment implicitly lacked Python, which was a required dependency for the `deasync` npm package during the `npm ci` step. Aligning the PHP version to 8.2 ensures that the build environment includes the necessary tools for Node.js native module compilation, resolving the `npm ci` failure.